### PR TITLE
Fix typo in README

### DIFF
--- a/stack_kotlin/README.md
+++ b/stack_kotlin/README.md
@@ -9,7 +9,7 @@ Stack based on
 ```
 brew cask install java
 brew install gradle
-gradlew wrapper
+gradle wrapper
 ```
 
 ## Local development


### PR DESCRIPTION
We spent quite some time figuring out that we needed to drop the `w` #kotlinnewbiesFTW